### PR TITLE
RPI4 / RPI3B 64 Bit Stereo Jack bcm2835 (Airplay support)

### DIFF
--- a/plugins/airplay/Dockerfile.template
+++ b/plugins/airplay/Dockerfile.template
@@ -1,23 +1,63 @@
-FROM mikebrady/shairport-sync:4.1.1 as shairport
+FROM alpine:3.18 as builder
 
+# Install dependencies for building Shairport Sync
+RUN apk add --no-cache \
+    build-base \
+    git \
+    autoconf \
+    automake \
+    libtool \
+    alsa-lib-dev \
+    pulseaudio-dev \
+    soxr-dev \
+    libconfig-dev \
+    avahi-dev \
+    openssl-dev \
+    dbus-dev \
+    popt-dev
 
+# Clone the Shairport Sync repository
 WORKDIR /usr/src
+RUN git clone https://github.com/mikebrady/shairport-sync.git
+WORKDIR /usr/src/shairport-sync
 
+# Checkout the desired version (4.1.1)
+RUN git checkout 4.1.1
+
+# Build Shairport Sync with PulseAudio support
+RUN autoreconf -i -f && \
+    ./configure --with-pa --with-alsa --with-avahi --with-soxr --with-ssl=openssl && \
+    make && \
+    make install
+
+# Final image
+FROM alpine:3.18
+
+# Install runtime dependencies
+RUN apk add --no-cache \
+    pulseaudio \
+    alsa-lib \
+    soxr \
+    libconfig \
+    avahi \
+    openssl \
+    dbus \
+    popt \
+    supervisor
+
+# Copy the built Shairport Sync binary
+COPY --from=builder /usr/local/bin/shairport-sync /usr/local/bin/shairport-sync
+
+# Set up working directory and environment variables
+WORKDIR /usr/src
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-
-# DL4006: https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/sh", "-eo", "pipefail", "-c"]
-
-# shairport-sync docker image doesn't include pulseaudio support so we use ALSA bridge
 ENV PULSE_SERVER=tcp:localhost:4317
-RUN apk update && apk add --no-cache supervisor curl~=7 && \
-  curl -skL https://raw.githubusercontent.com/balena-io-experimental/audio/master/scripts/alsa-bridge/alpine-setup.sh | sh \
-  && apk del curl
 
+# Copy configuration and scripts
 COPY start.sh /usr/src/
 COPY shairport-sync.conf /etc/shairport-sync.conf
 COPY supervisor.conf /usr/src/supervisor.conf
 
-# shairport-sync image entrypoint starts dbus and avahi daemons that we don't need
+# Set entrypoint and command
 ENTRYPOINT []
-CMD ["supervisord","-c","/usr/src/supervisor.conf"]
+CMD ["supervisord", "-c", "/usr/src/supervisor.conf"]


### PR DESCRIPTION
Issue:
- on rpi4 / rpi3 model b 64 bit os 
-> certain models of rpis depending on country of origin (maybe) have different audio jack drivers (two of mine use bcm2835 instead of the standard)
-> to account for this certain shims needed to be made


Shims:
BalenaCloud
-> Device Configuration
--> BALENA_HOST_CONFIG_dt_overlays = cma-320 (whole fleet)
--> BALENA_HOST_CONFIG_dt_overlay = "audio=on,vc3-fkms-v3d"
--> BALENA_HOST_CONFIG_hdmi_ignore_edid_audio = 1

-> Device Variables
--> AUDIO_OUTPUT = RPI_HEADPHONES
--> SOUND_VOLUME = 100


BalenaOS
-> airplay changes
---> shairpoint-sync.conf with output_backend="pa"
---> modification to Dockerfile.template to build sharepoint on the container with the flag --with-pa to enable output usage of custom backend

-> sound
---> modification to balena-sound.pa to append the default sink to be used for bcm2835


(some of these shims have already been made to the develop branch, this PR contains only airplay changes needed) 

